### PR TITLE
Release 3.6.1: document the 3.6.0 API in README + coverage/dartdoc/README house rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,19 @@ release. After a release, bump the dependency in `~/projects/hashlib`
 - _(new)_ When a change touches public API surface, update `example/` and
   `test_integration/main.dart` in the same commit if the new API belongs in the
   showcase — the integration job is the smoke test of the public surface.
+- _(new)_ **Always update `README.md` in the same commit as any public-API
+  change** — every new top-level `to`/`from`/`try` function, codec, alphabet
+  variant, or exported class gets a line in the relevant README section (the
+  "Supported codecs" table, an alphabet list, or the conveniences section), and
+  the install snippet's version tracks the release. README is a shipped artifact
+  scored by pana; a stale README is a release defect, not a follow-up.
+- _(new)_ **100% line coverage and 100% dartdoc are hard gates, not goals.**
+  Every commit keeps `lib/` at 100% line coverage (`bash scripts/coverage.sh`)
+  and every public symbol documented. New code ships in the same commit as the
+  tests that exercise all of its branches, and every public class, member,
+  constant, and top-level function carries dartdoc. Dartdoc is enforced by the
+  `public_member_api_docs` lint and pana; there is no coverage gate in CI, so
+  the coverage bar is on you — run the script before you commit.
 
 ## Failure modes — named, with the rule that prevents each
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.1
+
+- Update `README.md` for the 3.6.0 API: the `to<Name>Bytes` byte encoders, the
+  non-throwing `tryFrom<Name>` decoders, `constantTimeEquals`, the exported
+  converter base classes, and the case-insensitive Crockford decoding.
+
 # 3.6.0
 
 - [**Breaking Changes**]

--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ text. It carries no runtime dependencies of its own.
   raise typed errors on genuinely invalid input.
 - **Convenient output**: results integrate with `ByteCollector`, the digest
   container shared with `hashlib`, for one-call re-encoding.
+- **Bytes or strings, throwing or not**: every encoder has a `to<Name>Bytes`
+  twin returning a `Uint8List`, every decoder a non-throwing `tryFrom<Name>`
+  returning `null` on bad input, plus a top-level `constantTimeEquals` for
+  MAC/digest checks.
 
 ## Install
 
 ```yaml
 dependencies:
-  convertlib: ^3.5.2
+  convertlib: ^3.6.1
 ```
 
 or run `dart pub add convertlib`. A single import exposes every codec:
@@ -112,7 +116,8 @@ Every snippet in this README is also a runnable program in the
 - `Base32Codec.standard` (RFC-4648) — `ABCDEFGHIJKLMNOPQRSTUVWXYZ234567` (default)
 - `Base32Codec.lowercase` — `abcdefghijklmnopqrstuvwxyz234567`
 - `Base32Codec.hex` / `.hexLower` — base32hex, `0-9A-V` / `0-9a-v`
-- `Base32Codec.crockford` — `0123456789ABCDEFGHJKMNPQRSTVWXYZ`
+- `Base32Codec.crockford` — `0123456789ABCDEFGHJKMNPQRSTVWXYZ` (decoding is
+  case-insensitive and accepts `I`/`i`/`L`/`l` as `1` and `O`/`o` as `0`)
 - `Base32Codec.geohash` — `0123456789bcdefghjkmnpqrstuvwxyz`
 - `Base32Codec.z` — z-base-32, `ybndrfg8ejkmcpqxot1uwisza345h769`
 - `Base32Codec.wordSafe` — `23456789CFGHJMPQRVWXcfghjmpqrvwx`
@@ -128,6 +133,21 @@ to drop `=`, or a `codec:`:
 
 - `BigIntCodec.msbFirst` — treats bytes in big-endian order
 - `BigIntCodec.lsbFirst` — treats bytes in little-endian order (default)
+
+### Bytes, non-throwing decode, and constant-time compare
+
+- **Byte output** — every string encoder has a `to<Name>Bytes` twin that returns
+  the encoded ASCII output as a `Uint8List`, skipping the intermediate `String`:
+  `toHexBytes`, `toBinaryBytes`, `toOctalBytes`, `toBase32Bytes`, `toBase64Bytes`.
+- **Non-throwing decoders** — every decoder has a `tryFrom<Name>` that returns
+  `null` instead of throwing a `FormatException` on invalid input: `tryFromHex`,
+  `tryFromBinary`, `tryFromOctal`, `tryFromBase32`, `tryFromBase64`,
+  `tryFromUtf8`, `tryFromBigInt`.
+- **Constant-time compare** — `constantTimeEquals(a, b)` compares two byte lists
+  without exiting early on the first mismatch, for verifying MACs and digests.
+- **Low-level building blocks** — the generic converters `BitEncoder`/
+  `BitDecoder`, `ByteEncoder`/`ByteDecoder`, and `AlphabetEncoder`/
+  `AlphabetDecoder` are exported for building custom codecs.
 
 ### ByteCollector
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: convertlib
 description: Fast and error resilient codecs. Supports Base2, Base8, Base16,
   Base32, Base64, BigInt, UTF-8, and the PHC/crypt string format.
 homepage: https://github.com/bitanon/convertlib
-version: 3.6.0
+version: 3.6.1
 
 topics:
   - codec


### PR DESCRIPTION
A docs-only **3.6.1** patch: the README predated the 3.6.0 API. No library code changes.

## README (3.6.1)
- New **"Bytes, non-throwing decode, and constant-time compare"** section documenting the `to<Name>Bytes` byte encoders, the non-throwing `tryFrom<Name>` decoders, `constantTimeEquals`, and the exported converter base classes (`BitEncoder`/`ByteEncoder`/`AlphabetEncoder` + decoders).
- Noted that Crockford Base-32 decoding is case-insensitive and maps `I`/`i`/`L`/`l` → `1`, `O`/`o` → `0`.
- Added a Highlights bullet; refreshed the install snippet to `^3.6.1`.
- `pubspec.yaml` bumped to `3.6.1`; CHANGELOG entry added (pubspec == changelog heading).

## New AGENTS.md house rules
- **Always update `README.md`** in the same commit as any public-API change (new `to`/`from`/`try` function, codec, alphabet, or exported class) — a stale README is a release defect.
- **100% line coverage and 100% dartdoc are hard gates** — new code ships with the tests covering all its branches and dartdoc on every public symbol; run `scripts/coverage.sh` before committing (CI has no coverage gate).

Verified: version == changelog heading, `dart format` clean, `dart analyze --fatal-infos` clean, `dart test` green on vm **and** node (663 / 658), integration smoke test OK.

---
**Not done here** (your call): tagging `v3.6.1` and publishing. Merge this, then tag master — pubspec already reads `3.6.1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gWRo21gTugXust8dGLj4r)_